### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,4 +10,4 @@ IotsaOtaMod	KEYWORD1
 IotsaSimpleMod	KEYWORD1
 IotsaWifiMod	KEYWORD1
 IotsaLedMod	KEYWORD1
-IotsaLoggerMod KEYWORD1
+IotsaLoggerMod	KEYWORD1


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords